### PR TITLE
Turning off some of the CSS lint warnings

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -14,6 +14,13 @@ module.exports = function (grunt) {
         recess: {
             lint: {
                 src: ['css/**/*.css'],
+                options: {
+                    strictPropertyOrder: false,
+                    noOverqualifying: false,
+                    noUnderscores: false,
+                    zeroUnits: false,
+                    noIDs: false
+                }
             },
             compile: {
                 src: ['css/**/*.css'],


### PR DESCRIPTION
Seems the CSS raises a bunch of errors, maybe worth fixing them up later
but for the moment we'll be happy with basic linting
