### PR TITLE
Adding ability for grunt to run up a webserver

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,6 +129,15 @@ module.exports = function (grunt) {
                 }
             }
         },
+        connect: {
+            server: {
+                options: {
+                    port: 8000,
+                    base: 'dist',
+                    keepalive: true
+                }
+            }
+        },
         requirejs: {
             compile: {
                 options: {
@@ -170,5 +179,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-requirejs');
     grunt.loadNpmTasks('grunt-docco');
+    grunt.loadNpmTasks('grunt-contrib-connect');
 
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-contrib-watch": "~0.4.3",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-docco": "~0.3.0",
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.1",
+    "grunt-contrib-connect": "~0.5.0"
   }
 }


### PR DESCRIPTION
makes life simpler so there's no remembering what the python simple
server flag is
