### PR TITLE
adding shm shortcut for simple harmonic motion

### DIFF
--- a/coffee/core/time-keeper.coffee
+++ b/coffee/core/time-keeper.coffee
@@ -7,14 +7,16 @@
 define () ->
 
   class TimeKeeper
-    
+
     time: undefined
     timeAtStart: undefined
     milliseconds: undefined
-    
+    wave: undefined
+
     constructor: ->
       window.time = 0
-    
+      window.wave = (a) => @wave(a)
+
     updateTime: ->
       d = new Date()
       @time = d.getTime() - @timeAtStart
@@ -29,6 +31,10 @@ define () ->
 
     getTime: ->
       @time
+
+    # Wave: simple harmonic motion where a is period in milliseconds
+    wave: (a) ->
+      sin((@time/a) * Math.PI)
 
   TimeKeeper
 


### PR DESCRIPTION
I found this useful, not sure if you agree, but I added a shm (simple harmonic motion) global as an easy way to generate harmonic (back and forward) motion.  So when live coding, instead of this:

```
scale sin((time/1000) * Math.PI)
```

You can just write 

```
scale shm(1000)
```

I added it to timekeeper, I hope that's the right place!
