### PR TITLE
Getting image diff tests to actually run

### DIFF
--- a/tests/testsSource/testsSource.coffee
+++ b/tests/testsSource/testsSource.coffee
@@ -1,5 +1,16 @@
-require ['core/event-emitter','core/colour-literals','core/livecodelab-core'], (EventEmitter, ColourLiterals, LiveCodeLabCore) ->
+
+require [
+  'core/event-emitter',
+  'core/colour-literals',
+  'core/livecodelab-core'
+], (
+  EventEmitter,
+  ColourLiterals,
+  LiveCodeLabCore
+) ->
+
   describe "ImageTest", ->
+
     beforeEach ->
       @addMatchers imagediff.jasmine
 
@@ -14,6 +25,7 @@ require ['core/event-emitter','core/colour-literals','core/livecodelab-core'], (
       else
         if Bowser.chrome
           b.src = "test-page-files/images/ballCanvasChrome.png"
+
       console.log b.src
       testCanvas = document.createElement("canvas")
       testCanvas.width = 300
@@ -56,6 +68,7 @@ require ['core/event-emitter','core/colour-literals','core/livecodelab-core'], (
       else
         if Bowser.chrome
           b.src = "test-page-files/images/ballCanvasChrome.png"
+
       console.log b.src
       testCanvas = document.createElement("canvas")
       testCanvas.width = 300
@@ -84,3 +97,4 @@ require ['core/event-emitter','core/colour-literals','core/livecodelab-core'], (
       waits 200
       runs ->
         expect(a).toImageDiffEqual b, 0
+


### PR DESCRIPTION
changes to the livecodelab core object meant that the diff tests didn't run.

This doesn't fix the tests, but it does get them running
