### PR TITLE
Stats fixups

### DIFF
--- a/src/coffee/core/animation-loop.coffee
+++ b/src/coffee/core/animation-loop.coffee
@@ -10,8 +10,6 @@
 ## * the new 3d scene is rendered via Three.js
 ## * the beat of the sound system is changed if needed
 ## * the "frame" counter is incremented
-## * the stats widget in the top right corner is updated
-##   (it show either fps or milliseconds taken by each loop frame).
 ##
 ## Note that the followings are NOT done as part of the animation loop:
 ## * Syntax checking of the program typed by the user
@@ -64,7 +62,6 @@ class AnimationLoop
     @programRunner,
     @codeCompiler,
     @eventRouter,
-    @stats,
     @timeKeeper,
     @blendControls,
     @backgroundPainter,
@@ -168,6 +165,7 @@ class AnimationLoop
       @programRunner.putTicksNextToDoOnceBlocksThatHaveBeenRun(
         @codeCompiler
       )
+      @eventRouter.emit('frame-animated')
     else
       # the program is empty and so is the screen. Effectively, the user
       # is starting from scratch, so the frame should be reset to zero.
@@ -201,10 +199,6 @@ class AnimationLoop
     if !@sleeping and geometryOnScreenMightHaveChanged
       @renderer.render @graphicsCommands
       @graphicsCommands.atLeastOneObjectWasDrawn = @graphicsCommands.atLeastOneObjectIsDrawn
-
-
-    # update stats
-    if @stats then @stats.update()
 
   cleanStateBeforeRunningDrawAndRendering: ->
     @renderer.resetExclusionPrincipleWobbleDataIfNeeded @graphicsCommands

--- a/src/coffee/core/livecodelab-core.coffee
+++ b/src/coffee/core/livecodelab-core.coffee
@@ -222,6 +222,7 @@ class LiveCodeLabCore
         @graphicsCommands.resetTheSpinThingy = true
         @eventRouter.emit("clear-error")
         @programRunner.reset()
+        @eventRouter.emit("livecodelab-sleeping")
 
     if output.status is 'parsed' and @animationLoop.sleeping
       @animationLoop.sleeping = false

--- a/src/coffee/core/livecodelab-core.coffee
+++ b/src/coffee/core/livecodelab-core.coffee
@@ -87,8 +87,7 @@ class LiveCodeLabCore
     @backgroundDiv,
     @eventRouter,
     @syncClient,
-    @audioAPI,
-    @statsWidget
+    @audioAPI
   ) ->
 
     # three is a global defined in three.min.js and used in:
@@ -167,7 +166,6 @@ class LiveCodeLabCore
       @programRunner,
       @codeCompiler
       @eventRouter,
-      @statsWidget,
       @timeKeeper,
       @blendControls,
       @backgroundPainter,

--- a/src/coffee/languages/livelangv1/compiler.coffee
+++ b/src/coffee/languages/livelangv1/compiler.coffee
@@ -17,7 +17,7 @@ class CodeCompiler
   codePreprocessor: null
   lastCorrectOutput: null
 
-  whitespaceCheck: /^\s*$/
+  whitespaceCheck: /^\s*(\/\/[^\n]*\n*)*\s*$/
 
   constructor: (@eventRouter) ->
     # the code compiler needs the CodePreprocessor

--- a/src/coffee/languages/livelangv2/compiler.coffee
+++ b/src/coffee/languages/livelangv2/compiler.coffee
@@ -37,7 +37,7 @@ class V2CodeCompiler
       output.error = e
       return output
 
-    if (programAST.length == 0)
+    if (programAST.elements.length == 0)
       output.status = 'empty'
     else
       output.status = 'parsed'

--- a/src/coffee/lcl-init.coffee
+++ b/src/coffee/lcl-init.coffee
@@ -61,6 +61,10 @@ startEnvironment = (threeJsCanvas, backgroundDiv, paramsObject) ->
   # Stats are updated in the animationLoop
   # add Stats.js - https://github.com/mrdoob/stats.js
   stats = new Stats
+  eventRouter.addListener(
+    'frame-animated',
+    stats.update
+  )
 
   # Client used to sync to a time pulse over websocket
   syncClient = new Pulse()
@@ -95,8 +99,7 @@ startEnvironment = (threeJsCanvas, backgroundDiv, paramsObject) ->
     backgroundDiv,
     eventRouter,
     syncClient,
-    audioAPI,
-    stats
+    audioAPI
   )
 
   #/////////////////////////////////////////////////////

--- a/src/coffee/lcl-init.coffee
+++ b/src/coffee/lcl-init.coffee
@@ -180,6 +180,10 @@ startEnvironment = (threeJsCanvas, backgroundDiv, paramsObject) ->
     () -> ui.showStatsWidget()
   )
   eventRouter.addListener(
+    'livecodelab-sleeping',
+    () -> ui.hideStatsWidget()
+  )
+  eventRouter.addListener(
     'code-changed',
     (updatedCodeAsString) ->
       if updatedCodeAsString isnt ""
@@ -193,7 +197,6 @@ startEnvironment = (threeJsCanvas, backgroundDiv, paramsObject) ->
         )
         eventRouter.emit("set-url-hash", "")
         eventRouter.emit("big-cursor-show")
-        ui.hideStatsWidget()
       liveCodeLabCore.updateCode updatedCodeAsString
   )
 

--- a/src/grammar/lcl.pegjs
+++ b/src/grammar/lcl.pegjs
@@ -51,13 +51,15 @@ Program
 
 SourceElements "elements"
   = head:SourceElement tail:(NewLine SourceElement)* {
-      return buildList(head, tail, 1);
+      var elements = buildList(head, tail, 1);
+      return _.filter(elements, function (e) { return e.ast !== 'COMMENT'; });
   }
 
 SourceElement "elements"
-  = Samedent statement:Statement _ Comment* _ {
+  = Samedent statement:Statement _ Comment? {
       return statement;
   }
+  / Comment
 
 Block "block"
   = Indent elements:SourceElements Dedent {
@@ -372,10 +374,12 @@ Dedent
  */
 
 Comment
-  = "//" [^\n]*
+  = "//" [^\n]* {
+    return Ast.Node.Comment();
+  }
 
 NewLine
-  = Comment? "\n"+ Comment? NewLine?
+  = "\n"+
 
 EOF
   = !.

--- a/src/js/lcl/ast.js
+++ b/src/js/lcl/ast.js
@@ -149,5 +149,13 @@ Ast.Node.Str = function (value) {
     };
 };
 
+/**
+ */
+Ast.Node.Comment = function () {
+    return {
+        ast: 'COMMENT'
+    };
+};
+
 module.exports = Ast;
 

--- a/tests/livelangv1/compiler-tests.js
+++ b/tests/livelangv1/compiler-tests.js
@@ -1,0 +1,22 @@
+/* global describe, it */
+
+var assert = require('assert');
+
+var Compiler = require('../../src/coffee/languages/livelangv1/compiler');
+var GlobalScope = require('../../src/coffee/core/global-scope');
+
+describe('V1 Compiler', function() {
+
+  it('should identify sketches of just comments as empty', function () {
+
+    var scope = new GlobalScope();
+    var compiler = new Compiler({});
+
+    var program = '//test comment\n\n//another comment\n';
+    var output = compiler.compileCode(program, scope);
+
+    assert.equal(output.status, 'empty');
+
+  });
+
+});

--- a/tests/livelangv2/parser_comments_test.js
+++ b/tests/livelangv2/parser_comments_test.js
@@ -9,6 +9,16 @@ var assert = require('assert');
 
 describe('Comments', function () {
   
+  it('ignores single comments', function () {
+
+    var program = '// this is a comment';
+    var parsed = parser.parse(program, {});
+
+    var expected = ast.Block([]);
+
+    assert.deepEqual(parsed, expected);
+  });
+
   it('comments are ignored', function () {
 
     var program = dedent(`

--- a/tests/livelangv2/parser_full_test.js
+++ b/tests/livelangv2/parser_full_test.js
@@ -9,6 +9,16 @@ var assert = require('assert');
 
 describe('Parser', function () {
 
+  it('always returns a block, even with an empty program', function () {
+
+    var program = '';
+    var parsed = parser.parse(program, {});
+
+    var expected = ast.Block([]);
+
+    assert.deepEqual(parsed, expected);
+  });
+
   it('basic function calls work', function () {
 
     var program = dedent(`


### PR DESCRIPTION
This PR cleans up a few things around the stats widget.

* Stats widget is no longer passed all the way into core. there's an event that's fired after every succesfully animated frame that a listener hooks into to update the widget.
* Added a 'livecodelab-sleeping' event which is now hooked into to trigger hiding the stats widget.
* LiveLang V2 now has better comment handling and is better at figuring out if a sketch is empty.

fixes #142 
fixes #146 