### PR TITLE
Add an ending to a phrase that seemed cut off

### DIFF
--- a/docs/intros/language-intro.md
+++ b/docs/intros/language-intro.md
@@ -135,7 +135,7 @@ either <box>, <peg>
 either <box 2>, <peg 2>
 ```
 
-In this case, the *box* and *peg* functions 
+In this case, the *box* and *peg* functions are not evaluated. They are passed as arguments to the either function.
 
 
 "Scoped" matrix transformations


### PR DESCRIPTION
a minor correction in the doc. A phrase about passing functions to a function seemed cut off, so I completed it.