### PR TITLE
Small fix to gitattributes file format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 [core]
-	autocrlf = false
-	
+	autocrlf=false


### PR DESCRIPTION
I was getting a `is not a valid attribute name: .gitattributes:2` error when using git. seems that there are meant to be no spaces around the equal, even though the docs don't say that hah