### PR TITLE
Add support for shifting the BPM (useful for syncing two pulses with the same BPM)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -189,7 +189,8 @@ This is a reference of all the functions and variables available in LiveCodeLab.
 ### Play
 
 ### BPM
-
+    bpm: Number
+    bpmShift: Number
 
 ## Colour
 

--- a/src/coffee/core/time-keeper.coffee
+++ b/src/coffee/core/time-keeper.coffee
@@ -13,17 +13,18 @@ class TimeKeeper extends EventEmitter
 
     now = @audioApi.getTime()
 
-    @beatCount      = 1            # last whole beat number
-    @beatFraction   = 0            # fraction of the beat we're at
+    @beatCount       = 1            # last whole beat number
+    @beatFraction    = 0            # fraction of the beat we're at
 
-    @defaultBpm     = 100
-    @bpm            = 100
-    @newBpm         = 100
-    @mspb           = 60000 / @bpm # milliseconds per beat
+    @defaultBpm      = 100
+    @defaultBpmShift = 0
+    @bpm             = 100
+    @newBpm          = 100
+    @mspb            = 60000 / @bpm # milliseconds per beat
 
-    @lastBeatLoopMs = now          # milliseconds at last beat loop
-    @timeAtStart    = now          # milliseconds at loop start
-    @time           = now / 1000   # current time in SECONDS
+    @lastBeatLoopMs  = now          # milliseconds at last beat loop
+    @timeAtStart     = now          # milliseconds at loop start
+    @time            = now / 1000   # current time in SECONDS
 
     @resetTime()
     @beatLoop(now)
@@ -32,6 +33,7 @@ class TimeKeeper extends EventEmitter
 
     @scope = scope
     scope.addFunction('bpm',   (bpm) => @setBpm(bpm))
+    scope.addFunction('bpmShift', (bpmShift) => @setBpmShift(bpmShift))
     scope.addFunction('beat',  () => @beat())
     scope.addFunction('pulse', (frequency) => @pulse(frequency))
     scope.addFunction('wave',  (frequency) => @wave(frequency))
@@ -105,6 +107,12 @@ class TimeKeeper extends EventEmitter
     if (@bpm != bpm)
       @bpm = Math.max(20, Math.min(bpm, 250))
       @mspb = 60000 / @bpm
+
+  setBpmShift: (bpmShift) ->
+    if !(bpmShift?)
+      bpmShift = @defaultBpmShift
+    if (typeof bpmShift is 'number' and isFinite bpmShift and @bpmShift != bpmShift)
+      @bpmShift = bpmShift
 
   ###
   Connects to a sync server, and read the bpm/beat from there.


### PR DESCRIPTION
Two performers can have their bpms set to 40, but their pulses may be out of sync.

With this new function, `bpmShift K`, the pulse will shift K milliseconds, enabling the performers to go in-sync or out of sync.

This demo shows it clearly: https://www.youtube.com/watch?v=GBricHd6F1Y

Is a good thing that all the BPM and pulse logic lives in a single file!